### PR TITLE
编辑器控制台打印输出server代理url地址

### DIFF
--- a/build/config/cli-helper.ts
+++ b/build/config/cli-helper.ts
@@ -1,0 +1,58 @@
+/* eslint-disable */
+import process from 'node:process'
+import readline from 'node:readline'
+
+function clearScreen() {
+  const repeatCount = process.stdout.rows - 2
+  const blank = repeatCount > 0 ? '\n'.repeat(repeatCount) : ''
+  console.log(blank)
+  readline.cursorTo(process.stdout, 0, 0)
+  readline.clearScreenDown(process.stdout)
+}
+
+function formatter(open: string, close: string, replace = open) {
+  return (input: string) => {
+    const string = `${input}`
+    const index = string.indexOf(close, open.length)
+    return ~index ? open + replaceClose(string, close, replace, index) + close : open + string + close
+  }
+}
+
+function replaceClose(string: string, close: string, replace: string, index: number): string {
+  const start = string.substring(0, index) + replace
+  const end = string.substring(index + close.length)
+  const nextIndex = end.indexOf(close)
+  return ~nextIndex ? start + replaceClose(end, close, replace, nextIndex) : start + end
+}
+
+function createColors() {
+  return {
+    bgBlack: formatter('\x1B[40m', '\x1B[49m'),
+    bgBlue: formatter('\x1B[44m', '\x1B[49m'),
+    bgCyan: formatter('\x1B[46m', '\x1B[49m'),
+    bgGreen: formatter('\x1B[42m', '\x1B[49m'),
+    bgMagenta: formatter('\x1B[45m', '\x1B[49m'),
+    bgRed: formatter('\x1B[41m', '\x1B[49m', '\x1B[22m\x1B[1m'),
+    bgWhite: formatter('\x1B[47m', '\x1B[49m'),
+    bgYellow: formatter('\x1B[43m', '\x1B[49m'),
+    black: formatter('\x1B[30m', '\x1B[39m'),
+    blue: formatter('\x1B[34m', '\x1B[39m'),
+    bold: formatter('\x1B[1m', '\x1B[22m', '\x1B[22m\x1B[1m'),
+    cyan: formatter('\x1B[36m', '\x1B[39m'),
+    dim: formatter('\x1B[2m', '\x1B[22m', '\x1B[22m\x1B[2m'),
+    gray: formatter('\x1B[90m', '\x1B[39m'),
+    green: formatter('\x1B[32m', '\x1B[39m'),
+    hidden: formatter('\x1B[8m', '\x1B[28m'),
+    inverse: formatter('\x1B[7m', '\x1B[27m'),
+    italic: formatter('\x1B[3m', '\x1B[23m'),
+    magenta: formatter('\x1B[35m', '\x1B[39m'),
+    red: formatter('\x1B[31m', '\x1B[39m'),
+    reset: (s: string) => `\x1B[0m${s}\x1B[0m`,
+    strikethrough: formatter('\x1B[9m', '\x1B[29m'),
+    underline: formatter('\x1B[4m', '\x1B[24m'),
+    white: formatter('\x1B[37m', '\x1B[39m'),
+    yellow: formatter('\x1B[33m', '\x1B[39m'),
+  }
+}
+
+export { clearScreen, createColors }

--- a/build/config/proxy.ts
+++ b/build/config/proxy.ts
@@ -1,7 +1,10 @@
-import type { ProxyOptions } from 'vite';
+import type { HttpProxy, ProxyOptions } from 'vite';
 
 import { createServiceConfig } from '../../src/utils/service';
 
+import { clearScreen, createColors } from './cli-helper';
+
+const colors = createColors();
 /**
  * Set http proxy
  *
@@ -29,6 +32,17 @@ function createProxyItem(item: App.Service.ServiceConfigItem) {
 
   proxy[item.proxyPattern] = {
     changeOrigin: true,
+    configure: (_proxy: HttpProxy.Server, options: ProxyOptions) => {
+      _proxy.on('proxyReq', (_proxyReq, req, _res) => {
+        clearScreen();
+        // eslint-disable-next-line no-console
+        console.log(colors.bgYellow(`  ${req.method}  `), colors.green(`${options.target}${req.url}`));
+      });
+      _proxy.on('error', (_err, req, _res) => {
+        // eslint-disable-next-line no-console
+        console.log(colors.bgRed(`Error：${req.method}  `), colors.green(`${options.target}${req.url}`));
+      });
+    },
     rewrite: path => path.replace(new RegExp(`^${item.proxyPattern}`), ''),
     target: item.baseURL
   };


### PR DESCRIPTION


#### 我使用脚手架项目时喜欢在 vite 配置代理时显示的输出请求的目标路径。通过 proxy.configure可以做到这一点。
----
## 关于 cli-helper.ts

#### 我以前好奇 vite 项目启动时终端输出彩色重要信息。于是就去看了他的源码。将里面的主要成分提取出来，弄成了一个cli-helper.ts文件
<img width="755" alt="image" src="https://github.com/user-attachments/assets/3dec3476-fed0-4669-9f23-a9e2c3d8b88e" />
