### PR TITLE
update: 列设置拖拽事件影响点击事件

### DIFF
--- a/src/features/table/DragContent.tsx
+++ b/src/features/table/DragContent.tsx
@@ -33,10 +33,12 @@ const SortableItem: FC<{
       style={style}
       // 把拖拽所需的属性都附加上去
       {...attributes}
-      {...listeners}
       className="h-36px flex-y-center rd-4px hover:(bg-primary bg-opacity-20)"
     >
-      <IconMdiDrag className="mr-8px h-full cursor-move text-icon" />
+      <IconMdiDrag
+        className="mr-8px h-full cursor-move text-icon"
+        {...listeners}
+      />
       <ACheckbox
         checked={item.checked}
         className="none_draggable flex-1"


### PR DESCRIPTION
在列表组件中，列设置修改字段选中状态时，因为拖拽事件与复选框点击事件冲突，导致复选框更改状态需要双击