### PR TITLE
feat: 关闭 tab 标签时清理对应路由的 keepAlive 缓存

### DIFF
--- a/src/features/tab/GlobalTab.tsx
+++ b/src/features/tab/GlobalTab.tsx
@@ -55,7 +55,7 @@ const GlobalTab = () => {
 
   function handleCloseTab(tab: App.Global.Tab) {
     removeTabById(tab.id);
-    dispatch(setRemoveCacheKey(tab.routeKey));
+    dispatch(setRemoveCacheKey(tab.routePath));
   }
 
   function handleClickTab(tab: App.Global.Tab) {

--- a/src/layouts/modules/GlobalContent.tsx
+++ b/src/layouts/modules/GlobalContent.tsx
@@ -1,9 +1,11 @@
 import clsx from 'clsx';
 import KeepAlive, { useKeepAliveRef } from 'keepalive-for-react';
+import { useLocation, useOutlet } from 'react-router-dom';
 
 import { usePreviousRoute } from '@/features/router';
-import { selectCacheRoutes, selectRemoveCacheKey } from '@/features/router/routeStore';
+import { selectCacheRoutes, selectRemoveCacheKey, setRemoveCacheKey } from '@/features/router/routeStore';
 import { useThemeSettings } from '@/features/theme';
+import { useAppDispatch, useAppSelector } from '@/hooks/business/useStore';
 import { getReloadFlag } from '@/layouts/appStore';
 import './transition.css';
 
@@ -29,12 +31,16 @@ const GlobalContent = ({ closePadding }: Props) => {
 
   const themeSetting = useThemeSettings();
 
+  const dispatch = useAppDispatch();
+
   const transitionName = themeSetting.page.animate ? themeSetting.page.animateMode : '';
 
   useUpdateEffect(() => {
     if (!aliveRef.current || !removeCacheKey) return;
 
-    aliveRef.current.destroy(removeCacheKey);
+    aliveRef.current.destroy(removeCacheKey).then(() => {
+      dispatch(setRemoveCacheKey(null));
+    });
   }, [removeCacheKey]);
 
   useUpdateEffect(() => {


### PR DESCRIPTION
1.  Fixes # #45 
2. Feature: Tab 操作(关闭, 关闭其他, 关闭左侧, 关闭右侧, 关闭所有)会清理对应路由的 keepAlive 缓存 