### PR TITLE
fix(projects): in some cases, the tab homepage may be duplicated.

### DIFF
--- a/src/features/tab/tabHooks.ts
+++ b/src/features/tab/tabHooks.ts
@@ -280,7 +280,10 @@ export function useTabManager() {
 
       const initTabs = initTab(themeSettings.tab.cache, updateTabs);
 
-      if (!initTabs || initTabs.length === 0 || (initTabs.length > 0 && !isTabInTabs(tab.id, initTabs))) {
+      const existsInInit = Array.isArray(initTabs) && initTabs.length > 0 && isTabInTabs(tab.id, initTabs);
+      const existsInStore = isTabInTabs(tab.id, tabs);
+
+      if (!existsInInit && !existsInStore) {
         dispatch(addTab(tab));
       }
     } else if (!isTabInTabs(tab.id, tabs)) {


### PR DESCRIPTION
GlobalTab 重挂载时，useTabManager 的初始化分支只对本地缓存 initTabs 去重，没有对当前 Redux 中的 tabs 去重。在未启用缓存或缓存为空时，会再次 addTab 当前路由，导致首页被重复插入多个

修复：在初始化逻辑中，新增对当前 tabs 的存在性判断，只有当首页既不在缓存也不在 store 时才插入